### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jojo/laroute",
+    "name": "hostinger/laroute",
     "description": "Access Laravels URL/Route helper functions, from JavaScript or routes from JSON",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,12 @@
     ],
     "license" : "MIT",
     "require": {
-        "php" : ">=5.4.0",
-        "illuminate/support" : "5.*|^6.0|^7.0",
-        "illuminate/routing": "5.*|^6.0|^7.0",
-        "illuminate/console": "5.*|^6.0|^7.0",
-        "illuminate/config": "5.*|^6.0|^7.0",
-        "illuminate/filesystem": "5.*|^6.0|^7.0"
+        "php" : "^7.3|^8.0",
+        "laravel/framework": "^8.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "~4.0",
-        "mockery/mockery" : "dev-master"
+        "phpunit/phpunit" : "^9.0",
+        "mockery/mockery" : "^1.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/tests/src/Lord/Laroute/Compilers/TemplateCompilerTest.php
+++ b/tests/src/Lord/Laroute/Compilers/TemplateCompilerTest.php
@@ -2,13 +2,16 @@
 
 namespace Lord\Laroute\Compilers;
 
+use Jojo\Laroute\Compilers\CompilerInterface;
+use Jojo\Laroute\Compilers\TemplateCompiler;
 use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class TemplateCompilerTest extends \PHPUnit_Framework_TestCase
+class TemplateCompilerTest extends TestCase
 {
     protected $compiler;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -18,7 +21,7 @@ class TemplateCompilerTest extends \PHPUnit_Framework_TestCase
     public function testItIsOfTheCorrectInterface()
     {
         $this->assertInstanceOf(
-            'Lord\Laroute\Compilers\CompilerInterface',
+            CompilerInterface::class,
             $this->compiler
         );
     }
@@ -32,7 +35,7 @@ class TemplateCompilerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $this->compiler->compile($template, $data));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/src/Lord/Laroute/Generators/TemplateGeneratorTest.php
+++ b/tests/src/Lord/Laroute/Generators/TemplateGeneratorTest.php
@@ -2,9 +2,14 @@
 
 namespace Lord\Laroute\Generators;
 
+use Illuminate\Filesystem\Filesystem;
+use Jojo\Laroute\Compilers\CompilerInterface;
+use Jojo\Laroute\Generators\GeneratorInterface;
+use Jojo\Laroute\Generators\TemplateGenerator;
 use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class TemplateGeneratorTest extends \PHPUnit_Framework_TestCase
+class TemplateGeneratorTest extends TestCase
 {
     protected $compiler;
 
@@ -12,12 +17,12 @@ class TemplateGeneratorTest extends \PHPUnit_Framework_TestCase
 
     protected $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->compiler   = $this->mock('Lord\Laroute\Compilers\CompilerInterface');
-        $this->filesystem = $this->mock('Illuminate\Filesystem\Filesystem');
+        $this->compiler   = $this->mock(CompilerInterface::class);
+        $this->filesystem = $this->mock(Filesystem::class);
 
         $this->generator = new TemplateGenerator($this->compiler, $this->filesystem);
     }
@@ -25,7 +30,7 @@ class TemplateGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testItIsOfTheCorrectInterface()
     {
         $this->assertInstanceOf(
-            'Lord\Laroute\Generators\GeneratorInterface',
+            GeneratorInterface::class,
             $this->generator
         );
     }
@@ -63,7 +68,7 @@ class TemplateGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($actual, $filePath);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/src/Lord/Laroute/Routes/CollectionTest.php
+++ b/tests/src/Lord/Laroute/Routes/CollectionTest.php
@@ -2,19 +2,22 @@
 
 namespace Lord\Laroute\Routes;
 
+use Illuminate\Routing\RouteCollection;
+use Jojo\Laroute\Routes\Collection;
 use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class CollectionTest extends \PHPUnit_Framework_TestCase
+class CollectionTest extends TestCase
 {
     protected $routeCollection;
 
     protected $routes;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->routeCollection = $this->mock('Illuminate\Routing\RouteCollection');
+        $this->routeCollection = $this->mock(RouteCollection::class);
         $this->routes          = $this->createInstance();
     }
 
@@ -38,7 +41,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
Adds support for Laravel 8
Removes requires of `iluminate/*` repos, as they were moved inside `laravel/framework` in laravel 8